### PR TITLE
Made quoted arguments and docstring syntax consistent

### DIFF
--- a/cukes-rest-sample/src/test/resources/features/gadgets/Create Gadgets.feature
+++ b/cukes-rest-sample/src/test/resources/features/gadgets/Create Gadgets.feature
@@ -3,16 +3,16 @@ Feature: It is able to create Gadget records and add to the the database
   Scenario: Should create another Gadget object
 #   Please note that in json request body attribute
 #   id, createdDate, updatedDate values should be ignored and overwritten by the backend.
-    Given request body from file gadgets/requests/newGadget.json
+    Given request body from file "gadgets/requests/newGadget.json"
     And content type is "application/json"
 
-    When the client performs POST request on /gadgets
+    When the client performs POST request on "/gadgets"
     Then status code is 201
-    And header Location contains "http://localhost:8080/gadgets/"
+    And header "Location" contains "http://localhost:8080/gadgets/"
     And let variable "gadgetURL" equal to header "Location" value
 
     And should wait at most 30 seconds with interval 1 seconds until property "type" equal to "TABLET"
-    When the client performs GET request on {(header.Location)}
+    When the client performs GET request on "{(header.Location)}"
     Then status code is 200
     And response contains property "id" with value other than "2000"
     And response contains property "type" with value "TABLET"
@@ -25,19 +25,19 @@ Feature: It is able to create Gadget records and add to the the database
     And response does not contain property "updatedDate"
 
   Scenario: Server doesn't accept content-types other than JSON
-    Given request body from file gadgets/requests/newGadget.json
-    When the client performs POST request on /gadgets
+    Given request body from file "gadgets/requests/newGadget.json"
+    When the client performs POST request on "/gadgets"
     Then status code is 415
 
   Scenario: Server doesn't support adding record with empty Gadgets type
     Given request body "{}"
     And content type is "application/json"
-    When the client performs POST request on /gadgets
+    When the client performs POST request on "/gadgets"
     Then status code is 400
     And response equals to "Could not add new Gadget"
 
   Scenario: Server doesn't support adding Book Reader Gadgets
     Given request body "{"type": "INVALID_TYPE"}"
     And content type is "application/json"
-    When the client performs POST request on /gadgets
+    When the client performs POST request on "/gadgets"
     Then status code is 400

--- a/cukes-rest-sample/src/test/resources/features/gadgets/Delete Gadgets.feature
+++ b/cukes-rest-sample/src/test/resources/features/gadgets/Delete Gadgets.feature
@@ -1,21 +1,21 @@
 Feature: It is able to remove newly created Gadgets from the database
 
   Scenario: Should remove newly created Gadget
-    Given request body from file gadgets/requests/newGadget.json
+    Given request body from file "gadgets/requests/newGadget.json"
     And content type is "application/json"
 
-    When the client performs POST request on /gadgets
+    When the client performs POST request on "/gadgets"
     Then status code is 201
     And let variable "gadgetURL" equal to header "Location" value
 
-    When the client performs DELETE request on {(gadgetURL)}
+    When the client performs DELETE request on "{(gadgetURL)}"
     Then status code is 200
 
-    When the client performs GET request on {(gadgetURL)}
+    When the client performs GET request on "{(gadgetURL)}"
     Then status code is 404
     And response equals to "Object not found in the database"
 
   Scenario: Validation should fail if removal of Gadget is requested by invalid ID
-    When the client performs DELETE request on /gadgets/123456
+    When the client performs DELETE request on "/gadgets/123456"
     Then status code is 404
     And response equals to "Object not found in the database"

--- a/cukes-rest-sample/src/test/resources/features/gadgets/Read Gadgets.feature
+++ b/cukes-rest-sample/src/test/resources/features/gadgets/Read Gadgets.feature
@@ -1,12 +1,12 @@
 Feature: It is able to retrieve Gadget records stored in the database
 
   Scenario: Should retrieve all available Gadgets in an Array
-    When the client performs GET request on /gadgets
+    When the client performs GET request on "/gadgets"
     Then status code is 200
-    And response contains an array "gadgets" of size ">=5"
+    And response contains an array "gadgets" of size >= 5
 
   Scenario: Check attributes of a single Gadget record with ID - 1858 (search)
-    When the client performs GET request on /gadgets
+    When the client performs GET request on "/gadgets"
     Then status code is 200
     And response contains property "gadgets.find{gadget->gadget.id==1858}.id" with value "1858"
     And response contains property "gadgets.find{gadget->gadget.id==1858}.type" with value "LAPTOP"
@@ -18,7 +18,7 @@ Feature: It is able to retrieve Gadget records stored in the database
     And response does not contain property "gadgets.find{gadget->gadget.id==1858}.updatedDate"
 
   Scenario: Check attributes of a single Gadget record (request by ID)
-    When the client performs GET request on /gadgets/1860
+    When the client performs GET request on "/gadgets/1860"
     Then status code is 200
     And response contains property "id" with value "1860"
     And response contains property "type" with value "SMART_WATCH"
@@ -30,7 +30,7 @@ Feature: It is able to retrieve Gadget records stored in the database
     And response does not contain property "updatedDate"
 
   Scenario Outline: Checks the validation message if requesting invalid Gadget ID
-    When the client performs GET request on /gadgets/<ID>
+    When the client performs GET request on "/gadgets/<ID>"
     Then status code is 404
     And response equals to "Object not found in the database"
     Examples:
@@ -40,23 +40,23 @@ Feature: It is able to retrieve Gadget records stored in the database
 
   Scenario: Should get wrong expectation
     And should wait at most 30 seconds with interval 1 seconds until property "type" equal to "SMART_WATCH"
-    When the client performs GET request on /gadgets/1860
+    When the client performs GET request on "/gadgets/1860"
     Then a failure is expected
     And should wait at most 30 seconds with interval 1 seconds until property "type" equal to "NO_SUCH_TYPE" or fail with "SMART_WATCH"
-    When the client performs GET request on /gadgets/1860
-    And it fails with CucumberException
+    When the client performs GET request on "/gadgets/1860"
+    And it fails with "CucumberException"
 
   Scenario: Should fetch only one gadget with top param
     Given queryParam "$top" is "1"
-    When the client performs GET request on /gadgets
+    When the client performs GET request on "/gadgets"
     Then status code is 200
-    And response contains an array "gadgets" of size "1"
+    And response contains an array "gadgets" of size 1
 
 #  TODO: Remove first HTTP call once issue with scopes is fixed
   Scenario: Should fetch only one gadget with top param url encoded
     Given let variable "url_encoding_enabled" equal to "false"
-    When the client performs GET request on /gadgets
+    When the client performs GET request on "/gadgets"
     Then status code is 200
-    When the client performs GET request on /gadgets?%24top=1
+    When the client performs GET request on "/gadgets?%24top=1"
     Then status code is 200
-    And response contains an array "gadgets" of size "1"
+    And response contains an array "gadgets" of size 1

--- a/cukes-rest-sample/src/test/resources/features/gadgets/Update Gadgets.feature
+++ b/cukes-rest-sample/src/test/resources/features/gadgets/Update Gadgets.feature
@@ -1,14 +1,14 @@
 Feature: It is able to update newly Created Gadget
 
   Background:
-    Given request body from file gadgets/requests/newGadget.json
+    Given request body from file "gadgets/requests/newGadget.json"
     And content type is "application/json"
 
-    When the client performs POST request on /gadgets
+    When the client performs POST request on "/gadgets"
     Then status code is 201
     And let variable "gadgetURL" equal to header "Location" value
 
-    When the client performs GET request on {(gadgetURL)}
+    When the client performs GET request on "{(gadgetURL)}"
     Then status code is 200
     And response contains property "id" with value other than "2000"
     And let variable "id" equal to property "id" value
@@ -17,12 +17,12 @@ Feature: It is able to update newly Created Gadget
   Scenario: Should update existing Gadget object
 #   Please note that in json request body attribute
 #   id, createdDate, updatedDate values should be ignored and overwritten by the backend.
-    Given request body from file gadgets/requests/updatedGadget.json
+    Given request body from file "gadgets/requests/updatedGadget.json"
     And content type is "application/json"
-    When the client performs PUT request on {(gadgetURL)}
+    When the client performs PUT request on "{(gadgetURL)}"
     Then status code is 200
 
-    When the client performs GET request on {(gadgetURL)}
+    When the client performs GET request on "{(gadgetURL)}"
     Then status code is 200
     And response contains property "id" with value other than "3000"
     And response contains property "type" with value "LAPTOP"
@@ -36,26 +36,26 @@ Feature: It is able to update newly Created Gadget
     And response contains property "updatedDate" with value other than "1456326973103"
 
   Scenario: Server cannot update non-existing Gadget ID
-    Given request body from file gadgets/requests/updatedGadget.json
+    Given request body from file "gadgets/requests/updatedGadget.json"
     And content type is "application/json"
-    When the client performs PUT request on /gadgets/123456
+    When the client performs PUT request on "/gadgets/123456"
     Then status code is 400
     And response equals to "Could not update Gadget with ID: 123456"
 
   Scenario: Server doesn't accept for update content-types other than JSON
-    Given request body from file gadgets/requests/updatedGadget.json
-    When the client performs PUT request on {(gadgetURL)}
+    Given request body from file "gadgets/requests/updatedGadget.json"
+    When the client performs PUT request on "{(gadgetURL)}"
     Then status code is 415
 
   Scenario: Server doesn't support updating record to the one with empty Gadget type
     Given request body "{}"
     And content type is "application/json"
-    When the client performs PUT request on {(gadgetURL)}
+    When the client performs PUT request on "{(gadgetURL)}"
     Then status code is 400
     And response equals to "Could not update Gadget with ID: {(id)}"
 
   Scenario: Server doesn't support updating to Book Reader Gadgets
     Given request body "{"type": "INVALID_TYPE"}"
     And content type is "application/json"
-    When the client performs PUT request on {(gadgetURL)}
+    When the client performs PUT request on "{(gadgetURL)}"
     Then status code is 400

--- a/cukes-rest-sample/src/test/resources/features/healthcheck/healthcheck.feature
+++ b/cukes-rest-sample/src/test/resources/features/healthcheck/healthcheck.feature
@@ -1,38 +1,37 @@
 Feature: Server is healthy
 
   Background:
-    Given baseUri is http://localhost:8888/
+    Given baseUri is "http://localhost:8888/"
 
   Scenario: Should return pong response on /healthcheck
-    When the client performs GET request on /healthcheck
+    When the client performs GET request on "/healthcheck"
     Then status code is 200
     And let variable "var" equal to header "Content-Length" value
 
   Scenario: Scenario is isolated from another
-    When the client performs GET request on /healthcheck
+    When the client performs GET request on "/healthcheck"
     Then status code is 200
     Given request body "Hello. I'm Isolated!"
     Given queryParam "param" is "isolated"
 
   Scenario: GET is performed without extra request body
-    When the client performs GET request on /healthcheck
+    When the client performs GET request on "/healthcheck"
     Then status code is 200
     And let variable "{(isolated)}" equal to "not_isolated"
 
   Scenario: Float values should be compared correctly
-    Given baseUri is http://localhost:8080/
-    When the client performs GET request on /staticTypes
+    Given baseUri is "http://localhost:8080/"
+    When the client performs GET request on "/staticTypes"
     Then status code is 200
     Then response contains property "prop[0].float" with value "26.505515"
     Then response contains property "prop[0].string" with value "{(isolated)}"
 
   Scenario: Auto-cached variables are cleaned after each request
-    Given baseUri is http://localhost:8080/
-    When the client performs GET request on /customHeaders
+    Given baseUri is "http://localhost:8080/"
+    When the client performs GET request on "/customHeaders"
     Then status code is 200
 
-    When the client performs GET request on /staticTypes
+    When the client performs GET request on "/staticTypes"
     Then status code is 200
     # {(header.Custom-Header)} should be empty
     Then response contains property "prop[0].long" not matching pattern "{(header.Custom-Header)}"
-

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/api/GivenSteps.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/api/GivenSteps.java
@@ -23,22 +23,22 @@ public class GivenSteps {
     @Inject
     ResourceFileReader reader;
 
-    @Given("^let variable \"([^\"]+)\" equal to \"([^\"]+)\"$")
+    @Given("^let variable \"(.+)\" equal to \"(.+)\"$")
     public void var_assigned(String varName, String value) {
         world.put(varName, value);
     }
 
-    @Given("^baseUri is (.+)$")
+    @Given("^baseUri is \"(.+)\"$")
     public void base_Uri_Is(String url) {
         facade.baseUri(url);
     }
 
-    @Given("^resources root is (.+)$")
+    @Given("^resources root is \"(.+)\"$")
     public void resources_Root_Is(String url) {
         var_assigned(CukesOptions.RESOURCES_ROOT, url);
     }
 
-    @Given("^proxy settings are (http|https)://([^:]+)(?::(\\d+))?$")
+    @Given("^proxy settings are \"(http|https)://([^:]+)(?::(\\d+))?\"$")
     public void proxy(String scheme, String host, Integer port) {
         facade.proxy(scheme, host, port);
     }
@@ -88,42 +88,42 @@ public class GivenSteps {
         facade.body(body);
     }
 
-    @Given("^request body from file (.+)$")
+    @Given("^request body from file \"(.+)\"$")
     public void request_Body_From_File(String path) {
         facade.body(reader.read(path));
     }
 
-    @Given("^request body is a multipart file (.+)$")
+    @Given("^request body is a multipart file \"(.+)\"$")
     public void request_Body_Is_A_Multipart_File(String path) {
         facade.multiPart(new File(path));
     }
 
-    @Given("^session ID \"([^\"]+)\"$")
+    @Given("^session ID \"(.+)\"$")
     public void session_ID(String sessionId) {
         facade.sessionId(sessionId);
     }
 
-    @Given("^session ID \"([^\"]+)\" with value \"([^\"]+)\"$")
+    @Given("^session ID \"(.+)\" with value \"(.+)\"$")
     public void session_ID_With_Value(String sessionId, String value) {
         facade.sessionId(sessionId, value);
     }
 
-    @Given("^cookie \"([^\"]+)\" with value \"([^\"]+)\"$")
+    @Given("^cookie \"(.+)\" with value \"(.+)\"$")
     public void cookie_With_Value(String cookie, String value) {
         facade.cookie(cookie, value);
     }
 
-    @Given("^header ([^\"]+) with value \"([^\"]+)\"$")
+    @Given("^header ([^\"]+) with value \"(.+)\"$")
     public void header_With_Value(String name, String value) {
         facade.header(name, value);
     }
 
-    @Given("^username \"([^\"]+)\" and password \"([^\"]+)\"$")
+    @Given("^username \"(.+)\" and password \"(.+)\"$")
     public void authentication(String username, String password) {
         facade.authentication(username, password);
     }
 
-    @Given("^authentication type is \"([^\"]+)\"$")
+    @Given("^authentication type is \"(.+)\"$")
     public void authentication(String authenticationType) {
         facade.authenticationType(authenticationType);
     }

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/api/ThenSteps.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/api/ThenSteps.java
@@ -14,12 +14,12 @@ public class ThenSteps {
     @Inject
     private ResourceFileReader fileReader;
 
-    @Then("^let variable \"([^\"]+)\" equal to header \"([^\"]+)\" value$")
+    @Then("^let variable \"(.+)\" equal to header \"(.+)\" value$")
     public void var_assigned_from_header(String varName, String headerName) {
         assertionFacade.varAssignedFromHeader(varName, headerName);
     }
 
-    @Then("^let variable \"([^\"]+)\" equal to property \"([^\"]+)\" value$")
+    @Then("^let variable \"(.+)\" equal to property \"(.+)\" value$")
     public void var_assigned_fromProperty(String varName, String property) {
         assertionFacade.varAssignedFromProperty(varName, property);
     }
@@ -64,7 +64,7 @@ public class ThenSteps {
         assertionFacade.bodyContainsPathWithValue(path, value);
     }
 
-    @Then("^response contains property \"(.+)\" with value$")
+    @Then("^response contains property \"(.+)\" with value:$")
     public void response_Body_Contains_Property_Multiline(String path, String value) {
         assertionFacade.bodyContainsPathWithValue(path, value);
     }
@@ -79,9 +79,14 @@ public class ThenSteps {
         assertionFacade.bodyContainsPathOfType(path, type);
     }
 
-    @Then("^response contains an array \"(.+)\" of size \"(.+)\"$")
-    public void response_Body_Contains_Array_With_Size(String path, String size) {
-        assertionFacade.bodyContainsArrayWithSize(path, size);
+    @Then("^response contains an array \"(.+)\" of size (>=|>|<=|<) (\\d+)$")
+    public void response_Body_Contains_Array_With_Operator_Size(String path, String operator, Integer size) {
+        assertionFacade.bodyContainsArrayWithSize(path, operator + size);
+    }
+
+    @Then("^response contains an array \"(.+)\" of size (\\d+)$")
+    public void response_Body_Contains_Array_With_Size(String path, Integer size) {
+        assertionFacade.bodyContainsArrayWithSize(path, size.toString());
     }
 
     @Then("^response does not contain property \"(.+)\"")
@@ -99,12 +104,12 @@ public class ThenSteps {
         assertionFacade.bodyContainsPathNotMatchingPattern(path, pattern);
     }
 
-    @Then("^response contains properties from file (.+)$")
+    @Then("^response contains properties from file \"(.+)\"$")
     public void response_Body_Contains_Properties_From_File(String path) {
         assertionFacade.bodyContainsPropertiesFromJson(fileReader.read(path));
     }
 
-    @Then("^response contains properties from json")
+    @Then("^response contains properties from json:$")
     public void response_Body_Contains_Properties_From(String str) {
         assertionFacade.bodyContainsPropertiesFromJson(str);
     }
@@ -119,37 +124,37 @@ public class ThenSteps {
         assertionFacade.statusCodeIsNot(statusCode);
     }
 
-    @Then("^header (.+) is empty$")
+    @Then("^header \"(.+)\" is empty$")
     public void header_Is_Empty(String headerName) {
         assertionFacade.headerIsEmpty(headerName);
     }
 
-    @Then("^header (.+) is not empty$")
+    @Then("^header \"(.+)\" is not empty$")
     public void header_Is_Not_Empty(String headerName) {
         assertionFacade.headerIsNotEmpty(headerName);
     }
 
-    @Then("^header (.+) equal to \"(.+)\"$")
+    @Then("^header \"(.+)\" equal to \"(.+)\"$")
     public void header_Equal_To(String headerName, String value) {
         assertionFacade.headerEqualTo(headerName, value);
     }
 
-    @Then("^header (.+) not equal to \"(.+)\"$")
+    @Then("^header \"(.+)\" not equal to \"(.+)\"$")
     public void header_Not_Equal_To(String headerName, String value) {
         assertionFacade.headerNotEqualTo(headerName, value);
     }
 
-    @Then("^header (.+) contains \"(.+)\"$")
+    @Then("^header \"(.+)\" contains \"(.+)\"$")
     public void header_Contains(String headerName, String text) {
         assertionFacade.headerContains(headerName, text);
     }
 
-    @Then("^header (.+) does not contain \"(.+)\"$")
+    @Then("^header \"(.+)\" does not contain \"(.+)\"$")
     public void header_Does_Not_Contain(String headerName, String text) {
         assertionFacade.headerDoesNotContain(headerName, text);
     }
 
-    @Then("^header (.+) ends with pattern \"(.+)\"$")
+    @Then("^header \"(.+)\" ends with pattern \"(.+)\"$")
     public void header_Ends_With(String headerName, String suffix) {
         assertionFacade.headerEndsWith(headerName, suffix);
     }
@@ -159,7 +164,7 @@ public class ThenSteps {
         assertionFacade.failureIsExpected();
     }
 
-    @Then("^it fails with ([^\"]+)$")
+    @Then("^it fails with \"(.+)\"$")
     public void it_fails(String exceptionClass) {
         assertionFacade.failureOccurs(exceptionClass);
     }

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/api/WhenSteps.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/api/WhenSteps.java
@@ -10,7 +10,7 @@ public class WhenSteps {
     @Inject
     ResponseFacade facade;
 
-    @When("^the client performs (.+) request on (.+)$")
+    @When("^the client performs (.+) request on \"(.+)\"$")
     public void perform_Http_Request(String httpMethod, String url) throws Throwable {
         facade.doRequest(httpMethod, url);
     }

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/context/BaseContextHandler.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/context/BaseContextHandler.java
@@ -9,10 +9,12 @@ public abstract class BaseContextHandler {
 
     protected List<String> extractGroups(String pattern) {
         List<String> allMatches = new ArrayList<String>();
+
         Matcher m = Pattern.compile(GROUP_PATTERN).matcher(pattern);
         while (m.find()) {
             allMatches.add(m.group(1));
         }
+
         return allMatches;
     }
 }


### PR DESCRIPTION
Resolves #53 

### Summary

- Arguments are now all quoted with a few exceptions:
    - Number arguments (eg. `status code is 201`)
    - Http Method (eg. `the client performs POST request on "/"`)
- Docstring steps now has colon (:) at ending.
- All arguments allow quotes to be used within argument
    - An exception due to conflict on Await `or fail with`.
- Array size validation changed to have a more natural syntax
    - `response contains an array "gadgets" of size >= 5`
    - `response contains an array "gadgets" of size 1`