### PR TITLE
#52: Display response body for status code assertions

### DIFF
--- a/cukes-rest-sample/src/test/resources/cukes.properties
+++ b/cukes-rest-sample/src/test/resources/cukes.properties
@@ -1,3 +1,7 @@
+###
+# common
+###
+
 #default - http://localhost:80
 cukes.base_uri=http://localhost:8080
 
@@ -13,6 +17,20 @@ cukes.resources_root=src/test/resources/features
 #cukes.auth_type
 #cukes.username
 #cukes.password
+
+###
+# asserts
+###
+
+#default - false
+#cukes.asserts.status_code.display_body=true
+
+#default - no max
+#cukes.asserts.status_code.max_size=1024
+
+###
+# load runner
+###
 
 #default - true
 #cukes.context_inflating_enabled

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/CukesOptions.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/CukesOptions.java
@@ -17,6 +17,9 @@ public interface CukesOptions {
     String USERNAME = "username";
     String PASSWORD = "password";
 
+    String ASSERTS_STATUS_CODE_DISPLAY_BODY = "asserts.status_code.display_body";
+    String ASSERTS_STATUS_CODE_MAX_SIZE = "asserts.status_code.max_size";
+
     String URL_ENCODING_ENABLED = "url_encoding_enabled";
     String RELAXED_HTTPS = "relaxed_https";
     String CONTEXT_INFLATING_ENABLED = "context_inflating_enabled";

--- a/cukes-rest/src/test/java/lv/ctco/cukesrest/internal/AssertionFacadeImplTest.java
+++ b/cukes-rest/src/test/java/lv/ctco/cukesrest/internal/AssertionFacadeImplTest.java
@@ -2,9 +2,12 @@ package lv.ctco.cukesrest.internal;
 
 import com.google.common.base.*;
 import com.jayway.restassured.response.Response;
+import com.jayway.restassured.response.ValidatableResponse;
 import lv.ctco.cukesrest.internal.context.GlobalWorldFacade;
 import org.junit.Test;
 
+import static lv.ctco.cukesrest.CukesOptions.ASSERTS_STATUS_CODE_DISPLAY_BODY;
+import static lv.ctco.cukesrest.CukesOptions.ASSERTS_STATUS_CODE_MAX_SIZE;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
@@ -29,5 +32,118 @@ public class AssertionFacadeImplTest extends IntegrationTestBase {
         facade.varAssignedFromHeader("{(id)}", headerName);
         Optional<String> value = world.get("id");
         assertThat(value, equalToOptional(headerName));
+    }
+
+    @Test
+    public void shouldReturnBodyWhenEnabledWithMax() {
+        final ValidatableResponse validatableResponse = mock(ValidatableResponse.class);
+        when(validatableResponse.statusCode(anyInt())).thenThrow(new AssertionError("404 did not match 200."));
+
+        Response response = mock(Response.class);
+        when(response.getContentType()).thenReturn("application/json");
+        when(response.print()).thenReturn("An error occurred.");
+        when(response.getBody()).thenReturn(response);
+        when(response.then()).thenReturn(validatableResponse);
+
+        ResponseFacade mock = mock(ResponseFacade.class);
+        when(mock.response()).thenReturn(response);
+
+        ((AssertionFacadeImpl) facade).facade = mock;
+        world.put(ASSERTS_STATUS_CODE_DISPLAY_BODY, "true");
+        world.put(ASSERTS_STATUS_CODE_MAX_SIZE, "100");
+
+        validateException("404 did not match 200.\n\nBody:\nAn error occurred.");
+    }
+
+    @Test
+    public void shouldReturnBodyWhenEnabledAndNoMax() {
+        final ValidatableResponse validatableResponse = mock(ValidatableResponse.class);
+        when(validatableResponse.statusCode(anyInt())).thenThrow(new AssertionError("404 did not match 200."));
+
+        Response response = mock(Response.class);
+        when(response.getContentType()).thenReturn("application/json");
+        when(response.print()).thenReturn("An error occurred.");
+        when(response.getBody()).thenReturn(response);
+        when(response.then()).thenReturn(validatableResponse);
+
+        ResponseFacade mock = mock(ResponseFacade.class);
+        when(mock.response()).thenReturn(response);
+
+        ((AssertionFacadeImpl) facade).facade = mock;
+        world.put(ASSERTS_STATUS_CODE_DISPLAY_BODY, "true");
+
+        validateException("404 did not match 200.\n\nBody:\nAn error occurred.");
+    }
+
+    @Test
+    public void shouldNotReturnBodyWhenDisabled() {
+        final ValidatableResponse validatableResponse = mock(ValidatableResponse.class);
+        when(validatableResponse.statusCode(anyInt())).thenThrow(new AssertionError("404 did not match 200."));
+
+        Response response = mock(Response.class);
+        when(response.getContentType()).thenReturn("application/json");
+        when(response.print()).thenReturn("An error occurred.");
+        when(response.getBody()).thenReturn(response);
+        when(response.then()).thenReturn(validatableResponse);
+
+        ResponseFacade mock = mock(ResponseFacade.class);
+        when(mock.response()).thenReturn(response);
+
+        ((AssertionFacadeImpl) facade).facade = mock;
+        world.put(ASSERTS_STATUS_CODE_DISPLAY_BODY, "false");
+        world.put(ASSERTS_STATUS_CODE_MAX_SIZE, "100");
+
+        validateException("404 did not match 200.");
+    }
+
+    @Test
+    public void shouldNotReturnBodyWhenEnabledButLongerThanMaxSize() {
+        final ValidatableResponse validatableResponse = mock(ValidatableResponse.class);
+        when(validatableResponse.statusCode(anyInt())).thenThrow(new AssertionError("404 did not match 200."));
+
+        Response response = mock(Response.class);
+        when(response.getContentType()).thenReturn("application/json");
+        when(response.print()).thenReturn("An error occurred.");
+        when(response.getBody()).thenReturn(response);
+        when(response.then()).thenReturn(validatableResponse);
+
+        ResponseFacade mock = mock(ResponseFacade.class);
+        when(mock.response()).thenReturn(response);
+
+        ((AssertionFacadeImpl) facade).facade = mock;
+        world.put(ASSERTS_STATUS_CODE_DISPLAY_BODY, "true");
+        world.put(ASSERTS_STATUS_CODE_MAX_SIZE, "5");
+
+        validateException("404 did not match 200.\n\nBody:\n<exceeds max size>");
+    }
+
+    @Test
+    public void shouldNotReturnBodyWhenEnabledButContentTypeOctet() {
+        final ValidatableResponse validatableResponse = mock(ValidatableResponse.class);
+        when(validatableResponse.statusCode(anyInt())).thenThrow(new AssertionError("404 did not match 200."));
+
+        Response response = mock(Response.class);
+        when(response.getContentType()).thenReturn("application/octet-stream");
+        when(response.print()).thenReturn("An error occurred.");
+        when(response.getBody()).thenReturn(response);
+        when(response.then()).thenReturn(validatableResponse);
+
+        ResponseFacade mock = mock(ResponseFacade.class);
+        when(mock.response()).thenReturn(response);
+
+        ((AssertionFacadeImpl) facade).facade = mock;
+        world.put(ASSERTS_STATUS_CODE_DISPLAY_BODY, "true");
+        world.put(ASSERTS_STATUS_CODE_MAX_SIZE, "5000");
+
+        validateException("404 did not match 200.\n\nBody:\n<binary>");
+    }
+
+    private void validateException(String expectedMessage) {
+        try {
+            facade.statusCodeIs(200);
+            fail("Exception expected!");
+        } catch (AssertionError error) {
+            assertEquals(expectedMessage, error.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Resolves #52 

Output when enabled:
```text
    When the client performs GET request on "/healthcheck" # WhenSteps.perform_Http_Request(String,String)
    Then status code is 201                                # ThenSteps.response_Status_Code_Is(int)
      java.lang.AssertionError: 1 expectation failed.
      Expected status code <201> doesn't match actual status code <200>.

      Body:
      * deadlocks: OK
      * sample: OK
```

Output when enabled but content-type `application/octet-stream`:
```text
    When the client performs GET request on "/healthcheck" # WhenSteps.perform_Http_Request(String,String)
    Then status code is 201                                # ThenSteps.response_Status_Code_Is(int)
      java.lang.AssertionError: 1 expectation failed.
      Expected status code <201> doesn't match actual status code <200>.

      Body:
      <binary>
```


Output when enabled but exceeds max size:
```text
    When the client performs GET request on "/healthcheck" # WhenSteps.perform_Http_Request(String,String)
    Then status code is 201                                # ThenSteps.response_Status_Code_Is(int)
      java.lang.AssertionError: 1 expectation failed.
      Expected status code <201> doesn't match actual status code <200>.

      Body:
      <exceeds max size>
```