### PR TITLE
Add Maven badge and update waffle badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![Stories in Ready](https://badge.waffle.io/ctco/cukes-rest.png?label=ready&title=Ready)](https://waffle.io/ctco/cukes-rest)[![Join the chat at https://gitter.im/ctco/cukes-rest](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ctco/cukes-rest?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)[![Build Status](https://snap-ci.com/ctco/cukes-rest/branch/master/build_image)](https://snap-ci.com/ctco/cukes-rest/branch/master)
+[![Stories in Ready](https://img.shields.io/waffle/label/ctco/cukes-rest/ready.svg?label=Ready&style=flat)](https://waffle.io/ctco/cukes-rest)
+[![Join the chat at https://gitter.im/ctco/cukes-rest](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ctco/cukes-rest?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://snap-ci.com/ctco/cukes-rest/branch/master/build_image)](https://snap-ci.com/ctco/cukes-rest/branch/master)
+[![Maven](https://img.shields.io/maven-central/v/lv.ctco.cukesrest/cukes-rest-all.svg)](http://search.maven.org/#search|ga|1|lv.ctco.cukesrest)
+
 # ![cukes-rest logo](assets/cukes-rest-logo.png)
 **cukes-rest** takes simplicity of **Cucumber** and provides bindings for HTTP specification. As a sugar on top, **cukes-rest**
 adds steps for storing and using request/response content from a file system, variable support in .features, context 


### PR DESCRIPTION
The main purpose of this PR is to add the Maven badge so it's easy to view what the latest version is. In doing so I also updated the waffle badge to match the others using [Shields.io](http://shields.io/).

![image](https://cloud.githubusercontent.com/assets/475559/22954216/c80fc4d0-f2da-11e6-9324-10916c08afd4.png)
