### PR TITLE
#37: Introduce Logger concept to cukes-rest

### DIFF
--- a/cukes-rest-sample/pom.xml
+++ b/cukes-rest-sample/pom.xml
@@ -79,6 +79,13 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Logback -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.8</version>
+        </dependency>
+
         <!-- Dropwizard 0.6.2 (JDK 1.6 support) -->
         <dependency>
             <groupId>com.yammer.dropwizard</groupId>

--- a/cukes-rest-sample/server.yml
+++ b/cukes-rest-sample/server.yml
@@ -1,3 +1,19 @@
 http:
   port: 8080
   adminPort: 8888
+  requestLog:
+    console:
+      enabled: false
+    file:
+      enabled: false
+    syslog:
+      enabled: false
+
+logging:
+  level: INFO
+  console:
+    enabled: false
+  file:
+    enabled: false
+  syslog:
+    enabled: false

--- a/cukes-rest-sample/src/main/java/lv/ctco/cukesrest/SampleApplication.java
+++ b/cukes-rest-sample/src/main/java/lv/ctco/cukesrest/SampleApplication.java
@@ -1,10 +1,17 @@
 package lv.ctco.cukesrest;
 
-import com.google.inject.*;
-import com.yammer.dropwizard.*;
-import com.yammer.dropwizard.config.*;
-import lv.ctco.cukesrest.gadgets.*;
-import lv.ctco.cukesrest.healthcheck.*;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.yammer.dropwizard.Service;
+import com.yammer.dropwizard.config.Bootstrap;
+import com.yammer.dropwizard.config.Environment;
+import lv.ctco.cukesrest.gadgets.GadgetResource;
+import lv.ctco.cukesrest.healthcheck.CustomHeadersResource;
+import lv.ctco.cukesrest.healthcheck.StaticTypesResource;
+import org.slf4j.LoggerFactory;
 
 public class SampleApplication extends Service<SampleConfiguration> {
     public static void main(String[] args) throws Exception {
@@ -13,15 +20,26 @@ public class SampleApplication extends Service<SampleConfiguration> {
 
     @Override
     public void initialize(Bootstrap<SampleConfiguration> bootstrap) {
+        overrideLogging();
         bootstrap.setName("cukes-rest-sample-app");
     }
 
     @Override
-    public void run(SampleConfiguration configuration, Environment environment) {
+    public void run(SampleConfiguration configuration, Environment environment) throws JoranException {
+        overrideLogging();
         Injector injector = Guice.createInjector();
         environment.addResource(injector.getInstance(GadgetResource.class));
         environment.addResource(injector.getInstance(StaticTypesResource.class));
         environment.addResource(injector.getInstance(CustomHeadersResource.class));
         environment.addHealthCheck(injector.getInstance(SampleHealthCheck.class));
+    }
+
+    public static void overrideLogging() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        context.reset();
+        ContextInitializer initializer = new ContextInitializer(context);
+        try {
+            initializer.autoConfig();
+        } catch (JoranException ignored) {}
     }
 }

--- a/cukes-rest-sample/src/test/resources/cukes.properties
+++ b/cukes-rest-sample/src/test/resources/cukes.properties
@@ -11,12 +11,12 @@ cukes.resources_root=src/test/resources/features
 #cukes.proxy
 
 #default - false
-#cukes.url_encoding_enabled
-#cukes.relaxed_https
+#cukes.url_encoding_enabled=false
+#cukes.relaxed_https=false
 
 #cukes.auth_type
-#cukes.username
-#cukes.password
+#cukes.username=username
+#cukes.password=password
 
 ###
 # asserts
@@ -29,16 +29,31 @@ cukes.resources_root=src/test/resources/features
 #cukes.asserts.status_code.max_size=1024
 
 ###
+# logging
+###
+
+# default - lv.ctco.cukesrest.http
+#cukes.logging.http.logger.name=lv.ctco.cukesrest.http
+
+# default - none
+# options - all, body, cookies, headers, method, params, path
+#cukes.logging.http.requests.include=method,path,params
+
+# default - none
+# options - all, body, cookies, headers, status
+#cukes.logging.http.responses.include=headers,status
+
+###
 # load runner
 ###
 
 #default - true
-#cukes.context_inflating_enabled
+#cukes.context_inflating_enabled=true
 
 #default - false
-#cukes.assertions_disabled
+#cukes.assertions_disabled=false
 
 #default - false
-#cukes.loadrunner_filter_blocks_requests
+#cukes.loadrunner_filter_blocks_requests=false
 #cukes.plugins: com.mycompany.cukes.MyPlugin
 cukes.url_encoding_enabled=true

--- a/cukes-rest-sample/src/test/resources/logback.xml
+++ b/cukes-rest-sample/src/test/resources/logback.xml
@@ -1,0 +1,24 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Log request/response from rest assured through cukes-rest -->
+    <logger name="lv.ctco.cukesrest.http" level="INFO" />
+
+    <!-- Log request method and path, response status code -->
+    <!--<logger name="org.apache.http.impl.conn" level="DEBUG" />-->
+
+    <!-- Log request/response method and headers -->
+    <!--<logger name="org.apache.http.headers" level="DEBUG" />-->
+
+    <!-- Log request/response method, headers and raw body -->
+    <!--<logger name="org.apache.http.wire" level="DEBUG" />-->
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/cukes-rest/pom.xml
+++ b/cukes-rest/pom.xml
@@ -12,6 +12,7 @@
     </parent>
 
     <properties>
+        <sl4j.version>1.7.22</sl4j.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
 
@@ -39,6 +40,13 @@
     </build>
 
     <dependencies>
+        <!-- SL4J -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${sl4j.version}</version>
+        </dependency>
+
         <!-- JUnit -->
         <dependency>
             <groupId>junit</groupId>

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/CukesOptions.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/CukesOptions.java
@@ -20,6 +20,15 @@ public interface CukesOptions {
     String ASSERTS_STATUS_CODE_DISPLAY_BODY = "asserts.status_code.display_body";
     String ASSERTS_STATUS_CODE_MAX_SIZE = "asserts.status_code.max_size";
 
+    String OPTION_LOGGER_NAME = "logging.http.logger.name";
+    String DEFAULT_LOGGER_NAME = "lv.ctco.cukesrest.http";
+
+    String OPTION_REQUEST_INCLUDES = "logging.http.requests.include";
+    String DEFAULT_REQUEST_INCLUDES = "";
+
+    String OPTION_RESPONSE_INCLUDES = "logging.http.responses.include";
+    String DEFAULT_RESPONSE_INCLUDES = "";
+
     String URL_ENCODING_ENABLED = "url_encoding_enabled";
     String RELAXED_HTTPS = "relaxed_https";
     String CONTEXT_INFLATING_ENABLED = "context_inflating_enabled";

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/CukesOptions.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/CukesOptions.java
@@ -20,14 +20,9 @@ public interface CukesOptions {
     String ASSERTS_STATUS_CODE_DISPLAY_BODY = "asserts.status_code.display_body";
     String ASSERTS_STATUS_CODE_MAX_SIZE = "asserts.status_code.max_size";
 
-    String OPTION_LOGGER_NAME = "logging.http.logger.name";
-    String DEFAULT_LOGGER_NAME = "lv.ctco.cukesrest.http";
-
-    String OPTION_REQUEST_INCLUDES = "logging.http.requests.include";
-    String DEFAULT_REQUEST_INCLUDES = "";
-
-    String OPTION_RESPONSE_INCLUDES = "logging.http.responses.include";
-    String DEFAULT_RESPONSE_INCLUDES = "";
+    String LOGGING_LOGGER_NAME = "logging.http.logger.name";
+    String LOGGING_REQUEST_INCLUDES = "logging.http.requests.include";
+    String LOGGING_RESPONSE_INCLUDES = "logging.http.responses.include";
 
     String URL_ENCODING_ENABLED = "url_encoding_enabled";
     String RELAXED_HTTPS = "relaxed_https";

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/CukesRestPlugin.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/CukesRestPlugin.java
@@ -1,5 +1,8 @@
 package lv.ctco.cukesrest;
 
+import com.jayway.restassured.response.Response;
+import com.jayway.restassured.specification.RequestSpecification;
+
 public interface CukesRestPlugin {
 
     void beforeAllTests();
@@ -10,7 +13,7 @@ public interface CukesRestPlugin {
 
     void afterScenario();
 
-    void beforeRequest();
+    void beforeRequest(RequestSpecification requestSpecification);
 
-    void afterRequest();
+    void afterRequest(Response response);
 }

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/HttpMethod.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/HttpMethod.java
@@ -17,7 +17,6 @@ public enum HttpMethod {
     }
 
     public Response doRequest(RequestSpecification when, String url) {
-        when = when.log().path();
         switch (this) {
             case GET: return when.get(url);
             case POST: return when.post(url);

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/RequestSpecificationFacade.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/RequestSpecificationFacade.java
@@ -1,24 +1,35 @@
 package lv.ctco.cukesrest.internal;
 
-import com.google.common.base.*;
-import com.google.inject.*;
-import com.jayway.restassured.*;
-import com.jayway.restassured.path.json.config.*;
-import com.jayway.restassured.specification.*;
-import lv.ctco.cukesrest.*;
-import lv.ctco.cukesrest.internal.context.*;
-import lv.ctco.cukesrest.internal.helpers.*;
-import lv.ctco.cukesrest.internal.https.*;
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.path.json.config.JsonPathConfig;
+import com.jayway.restassured.specification.RequestSpecification;
+import lv.ctco.cukesrest.CukesOptions;
+import lv.ctco.cukesrest.CukesRuntimeException;
+import lv.ctco.cukesrest.internal.context.GlobalWorldFacade;
+import lv.ctco.cukesrest.internal.context.InflateContext;
+import lv.ctco.cukesrest.internal.helpers.Time;
+import lv.ctco.cukesrest.internal.https.TrustAllTrustManager;
+import lv.ctco.cukesrest.internal.logging.LoggerPrintStream;
+import org.slf4j.event.Level;
 
-import java.io.*;
-import java.net.*;
+import java.io.File;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
 
 import static com.jayway.restassured.config.DecoderConfig.ContentDecoder.DEFLATE;
 import static com.jayway.restassured.config.DecoderConfig.decoderConfig;
-import static com.jayway.restassured.config.JsonConfig.*;
-import static com.jayway.restassured.config.RestAssuredConfig.*;
+import static com.jayway.restassured.config.JsonConfig.jsonConfig;
+import static com.jayway.restassured.config.LogConfig.logConfig;
+import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 import static lv.ctco.cukesrest.internal.matchers.ResponseMatcher.*;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.slf4j.LoggerFactory.getLogger;
 
 @Singleton
 @InflateContext
@@ -52,7 +63,8 @@ public class RequestSpecificationFacade {
             try {
                 uri = new URI($proxy.get());
                 specification.proxy(uri);
-            } catch (URISyntaxException ignore) {}
+            } catch (URISyntaxException ignore) {
+            }
         }
 
         boolean urlEncodingEnabled = world.getBoolean(CukesOptions.URL_ENCODING_ENABLED);
@@ -160,7 +172,9 @@ public class RequestSpecificationFacade {
         try {
             // TODO: Somehow this should be configurable
             specification = RestAssured.given()
-                .config(newConfig().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.BIG_DECIMAL)));
+                .config(newConfig()
+                    .jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.BIG_DECIMAL)));
+
             awaitCondition = null;
             onCreate();
         } catch (Exception e) {

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/ResponseFacade.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/ResponseFacade.java
@@ -3,6 +3,7 @@ package lv.ctco.cukesrest.internal;
 import com.google.common.base.Optional;
 import com.google.inject.*;
 import com.jayway.restassured.response.*;
+import com.jayway.restassured.specification.RequestSpecification;
 import lv.ctco.cukesrest.*;
 import lv.ctco.cukesrest.internal.context.*;
 import lv.ctco.cukesrest.internal.matchers.*;
@@ -73,12 +74,16 @@ public class ResponseFacade {
             @Override
             public ResponseWrapper call() throws Exception {
                 authenticate();
+
+                final RequestSpecification requestSpec = specification.value();
+
                 for (CukesRestPlugin cukesRestPlugin : pluginSet) {
-                    cukesRestPlugin.beforeRequest();
+                    cukesRestPlugin.beforeRequest(requestSpec);
                 }
-                response = method.doRequest(specification.value(), url);
+
+                response = method.doRequest(requestSpec, url);
                 for (CukesRestPlugin cukesRestPlugin : pluginSet) {
-                    cukesRestPlugin.afterRequest();
+                    cukesRestPlugin.afterRequest(response);
                 }
                 if (!filterEnabled) {
                     cacheHeaders(response);

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/di/CukesGuiceModule.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/di/CukesGuiceModule.java
@@ -7,6 +7,7 @@ import lv.ctco.cukesrest.*;
 import lv.ctco.cukesrest.internal.AssertionFacade;
 import lv.ctco.cukesrest.internal.AssertionFacadeImpl;
 import lv.ctco.cukesrest.internal.context.*;
+import lv.ctco.cukesrest.internal.logging.HttpLoggingPlugin;
 import lv.ctco.cukesrest.internal.switches.*;
 import org.aopalliance.intercept.*;
 
@@ -55,6 +56,11 @@ public class CukesGuiceModule extends AbstractModule {
     private void bindPlugins() {
         try {
             Multibinder<CukesRestPlugin> multibinder = Multibinder.newSetBinder(binder(), CukesRestPlugin.class);
+
+            // add our own plugins
+            multibinder.addBinding().to(HttpLoggingPlugin.class);
+
+            // add user configured plugins
             ClassLoader classLoader = CukesGuiceModule.class.getClassLoader();
             Properties prop = new Properties();
             URL url = createCukesPropertyFileUrl(classLoader);

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/logging/HttpLoggingPlugin.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/logging/HttpLoggingPlugin.java
@@ -30,13 +30,17 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 public class HttpLoggingPlugin implements CukesRestPlugin {
 
+    private static final String DEFAULT_LOGGER_NAME = "lv.ctco.cukesrest.http";
+    private static final String DEFAULT_REQUEST_INCLUDES = "";
+    private static final String DEFAULT_RESPONSE_INCLUDES = "";
+
     private final PrintStream logStream;
     private final GlobalWorldFacade world;
 
     @Inject
     public HttpLoggingPlugin(GlobalWorldFacade world) {
         this.world = world;
-        logStream = new LoggerPrintStream(getLogger(world.get(OPTION_LOGGER_NAME, DEFAULT_LOGGER_NAME)), Level.INFO);
+        logStream = new LoggerPrintStream(getLogger(world.get(LOGGING_LOGGER_NAME, DEFAULT_LOGGER_NAME)), Level.INFO);
     }
 
     @Override
@@ -75,13 +79,13 @@ public class HttpLoggingPlugin implements CukesRestPlugin {
             .config(config.logConfig(logConfig().defaultStream(logStream)))
             .log();
 
-        final List<LogDetail> logDetails = parseLogDetails(world.get(OPTION_REQUEST_INCLUDES, DEFAULT_REQUEST_INCLUDES));
+        final List<LogDetail> logDetails = parseLogDetails(world.get(LOGGING_REQUEST_INCLUDES, DEFAULT_REQUEST_INCLUDES));
         applyRequestLogDetails(logDetails, logSpec);
     }
 
     @Override
     public void afterRequest(Response response) {
-        final List<LogDetail> logDetails = parseLogDetails(world.get(OPTION_RESPONSE_INCLUDES, DEFAULT_RESPONSE_INCLUDES));
+        final List<LogDetail> logDetails = parseLogDetails(world.get(LOGGING_RESPONSE_INCLUDES, DEFAULT_RESPONSE_INCLUDES));
         applyResponseLogDetails(logDetails, response.then().log());
     }
 

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/logging/HttpLoggingPlugin.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/logging/HttpLoggingPlugin.java
@@ -1,0 +1,162 @@
+package lv.ctco.cukesrest.internal.logging;
+
+import com.google.common.base.Function;
+import com.google.common.base.Splitter;
+import com.google.inject.Inject;
+import com.jayway.restassured.config.RestAssuredConfig;
+import com.jayway.restassured.filter.log.LogDetail;
+import com.jayway.restassured.response.Response;
+import com.jayway.restassured.response.ValidatableResponseLogSpec;
+import com.jayway.restassured.specification.FilterableRequestSpecification;
+import com.jayway.restassured.specification.RequestLogSpecification;
+import com.jayway.restassured.specification.RequestSpecification;
+import lv.ctco.cukesrest.CukesRestPlugin;
+import lv.ctco.cukesrest.internal.context.GlobalWorldFacade;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.event.Level;
+
+import java.io.PrintStream;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import static com.google.common.collect.Collections2.transform;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.intersection;
+import static com.google.common.collect.Sets.newHashSet;
+import static com.jayway.restassured.config.LogConfig.logConfig;
+import static lv.ctco.cukesrest.CukesOptions.*;
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class HttpLoggingPlugin implements CukesRestPlugin {
+
+    private final PrintStream logStream;
+    private final GlobalWorldFacade world;
+
+    @Inject
+    public HttpLoggingPlugin(GlobalWorldFacade world) {
+        this.world = world;
+        logStream = new LoggerPrintStream(getLogger(world.get(OPTION_LOGGER_NAME, DEFAULT_LOGGER_NAME)), Level.INFO);
+    }
+
+    @Override
+    public void beforeAllTests() {
+
+    }
+
+    @Override
+    public void afterAllTests() {
+
+    }
+
+    @Override
+    public void beforeScenario() {
+
+    }
+
+    @Override
+    public void afterScenario() {
+
+    }
+
+    @Override
+    public void beforeRequest(RequestSpecification requestSpecification) {
+        RestAssuredConfig config;
+
+        // need to do this until https://github.com/rest-assured/rest-assured/issues/824 is available
+        if (requestSpecification instanceof FilterableRequestSpecification) {
+            config = ((FilterableRequestSpecification) requestSpecification).getConfig();
+        } else {
+            throw new IllegalArgumentException(
+                "Don't know how to retrieve current configuration from " + requestSpecification);
+        }
+
+        final RequestLogSpecification logSpec = requestSpecification
+            .config(config.logConfig(logConfig().defaultStream(logStream)))
+            .log();
+
+        final List<LogDetail> logDetails = parseLogDetails(world.get(OPTION_REQUEST_INCLUDES, DEFAULT_REQUEST_INCLUDES));
+        applyRequestLogDetails(logDetails, logSpec);
+    }
+
+    @Override
+    public void afterRequest(Response response) {
+        final List<LogDetail> logDetails = parseLogDetails(world.get(OPTION_RESPONSE_INCLUDES, DEFAULT_RESPONSE_INCLUDES));
+        applyResponseLogDetails(logDetails, response.then().log());
+    }
+
+    private List<LogDetail> parseLogDetails(final String logDetailsString) {
+        if (StringUtils.isBlank(logDetailsString)) return newArrayList();
+
+        final HashSet<String> logDetailsStrings = newHashSet(Splitter.on(",").trimResults().omitEmptyStrings().split(logDetailsString));
+        final HashSet<String> validLogDetailsStrings = newHashSet(transform(newArrayList(LogDetail.values()), new Function<LogDetail, String>() {
+            @Override
+            public String apply(LogDetail logDetail) {
+                return logDetail.name().toLowerCase();
+            }
+        }));
+
+        final Collection<LogDetail> logDetails = transform(intersection(logDetailsStrings, validLogDetailsStrings), new Function<String, LogDetail>() {
+            @Override
+            public LogDetail apply(String s) {
+                return LogDetail.valueOf(s.toUpperCase());
+            }
+        });
+
+        return newArrayList(logDetails.iterator());
+    }
+
+    private void applyRequestLogDetails(List<LogDetail> details, RequestLogSpecification logSpec) {
+        if (details.isEmpty()) return;
+
+        for (LogDetail detail : details) {
+            switch (detail) {
+                case ALL:
+                    logSpec.all();
+                    return;
+                case BODY:
+                    logSpec.body();
+                    break;
+                case COOKIES:
+                    logSpec.cookies();
+                    break;
+                case HEADERS:
+                    logSpec.headers();
+                    break;
+                case METHOD:
+                    logSpec.method();
+                    break;
+                case PARAMS:
+                    logSpec.parameters();
+                    break;
+                case PATH:
+                    logSpec.path();
+                    break;
+            }
+        }
+    }
+
+    private void applyResponseLogDetails(List<LogDetail> details, ValidatableResponseLogSpec logSpec) {
+        if (details.isEmpty()) return;
+
+        for (LogDetail detail : details) {
+            switch (detail) {
+                case ALL:
+                    logSpec.all();
+                    return;
+                case BODY:
+                    logSpec.body();
+                    break;
+                case COOKIES:
+                    logSpec.cookies();
+                    break;
+                case HEADERS:
+                    logSpec.headers();
+                    break;
+                case STATUS:
+                    logSpec.status();
+                    break;
+            }
+        }
+    }
+}

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/logging/LoggerPrintStream.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/logging/LoggerPrintStream.java
@@ -1,0 +1,63 @@
+package lv.ctco.cukesrest.internal.logging;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public class LoggerPrintStream extends PrintStream {
+
+    public LoggerPrintStream(Logger logger, Level level) {
+        super(new LoggerOutputStream(logger, level), true);
+    }
+
+    private static class LoggerOutputStream extends OutputStream {
+
+        private final Logger logger;
+        private final Level level;
+        private StringBuilder stringBuilder = new StringBuilder();
+
+        LoggerOutputStream(Logger logger, Level level) {
+            this.logger = logger;
+            this.level = level;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            stringBuilder.append((char) b);
+        }
+
+        @Override
+        public void flush() {
+            log(logger, level, stringBuilder.toString());
+            stringBuilder = new StringBuilder();
+        }
+
+        private void log(Logger logger, Level level, String message) {
+
+            if (StringUtils.isBlank(message)) return;
+
+            switch (level) {
+                case TRACE:
+                    logger.trace(message);
+                    break;
+                case DEBUG:
+                    logger.debug(message);
+                    break;
+                case INFO:
+                    logger.info(message);
+                    break;
+                case WARN:
+                    logger.warn(message);
+                    break;
+                case ERROR:
+                    logger.error(message);
+                    break;
+            }
+        }
+    }
+
+}

--- a/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/matchers/JsonMatchers.java
+++ b/cukes-rest/src/main/java/lv/ctco/cukesrest/internal/matchers/JsonMatchers.java
@@ -1,21 +1,24 @@
 package lv.ctco.cukesrest.internal.matchers;
 
-import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
-
-import java.util.List;
-
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-
 import com.jayway.restassured.internal.RestAssuredResponseOptionsImpl;
 import com.jayway.restassured.path.xml.XmlPath;
 import com.jayway.restassured.path.xml.config.XmlPathConfig;
 import com.jayway.restassured.response.ResponseBodyExtractionOptions;
-
 import lv.ctco.cukesrest.internal.helpers.Strings;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 
 public class JsonMatchers {
+
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonMatchers.class);
 
     // TODO: Collect and show all mismatch
     public static Matcher<ResponseBodyExtractionOptions> containsValueByPath(final String path, final Matcher<?> matcher) {
@@ -44,6 +47,7 @@ public class JsonMatchers {
                     }
                     return matcher.matches(this.value);
                 } catch (Exception e) {
+                    LOGGER.info(e.getMessage(), e);
                     return false;
                 }
             }

--- a/cukes-rest/src/test/java/lv/ctco/cukesrest/RequestBody.java
+++ b/cukes-rest/src/test/java/lv/ctco/cukesrest/RequestBody.java
@@ -1,7 +1,8 @@
 package lv.ctco.cukesrest;
 
-import com.jayway.restassured.config.*;
-import com.jayway.restassured.internal.*;
+import com.jayway.restassured.config.RestAssuredConfig;
+import com.jayway.restassured.internal.ResponseParserRegistrar;
+import com.jayway.restassured.internal.RestAssuredResponseOptionsImpl;
 
 public class RequestBody extends RestAssuredResponseOptionsImpl {
 


### PR DESCRIPTION
## Summary

This PR should resolve the initial requests from #37. It adds a configurable logger that can then be reported through with any [sl4j](https://www.slf4j.org/) compatible logging library. See sample application for sample dependencies and configuration (logback.xml).

#### Sample Request Output (all)
```
14:55:00.157 [main] INFO  lv.ctco.cukesrest.http - Request method:	POST
Request path:	http://localhost:8080/gadgets
Proxy:			<none>
Request params:	<none>
Query params:	<none>
Form params:	<none>
Path params:	<none>
Multiparts:		<none>
Headers:		Accept=*/*
				Content-Type=application/json; charset=UTF-8
Cookies:		<none>
Body:
{
    "id": 2000,
    "type": "TABLET",
    "name": "Nexus 9",
    "owner": {
        "name": "Ned",
        "surname": "Flanders",
        "roles": [
            "maLL-owner",
            "EvanGEliST"
        ],
        "age": 43
    },
    "createdDate": 1455114963103,
    "updatedDate": 1456326973103
}
```


#### Sample Response Output (all)
```
14:55:00.179 [main] INFO  lv.ctco.cukesrest.http - HTTP/1.1 200 OK
Date: Wed, 01 Mar 2017 20:55:00 GMT
Content-Type: application/json
Content-Encoding: gzip
Vary: Accept-Encoding, User-Agent
Transfer-Encoding: chunked

{
    "id": 1863,
    "type": "TABLET",
    "name": "Nexus 9",
    "owner": {
        "name": "Ned",
        "surname": "Flanders",
        "age": 43,
        "roles": [
            "maLL-owner",
            "EvanGEliST"
        ]
    },
    "createdDate": 1488401700165,
    "updatedDate": null
}
```

#### Note on tests
I wasn't able to write any tests for this because I'm not entirely sure which method to facilitate tests. I can go with some unit tests within `HttpLoggingPlugin` but not sure what I'd be testing other than configuration parsing. Other than that Rest-Assured doesn't lend itself to unit testing in the way that we are using it. It's  almost as if we need some integration tests at the library level. If that's preferable, I can invest additional time to add some.